### PR TITLE
PyPI Package Setup - Enable pip install deepdiver #7

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 gerico1007
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include README.md
+include LICENSE
+include ROADMAP.md
+include CLAUDE.md
+recursive-include deepdiver *.yaml *.yml
+recursive-include tests *.py
+global-exclude __pycache__
+global-exclude *.py[co]
+global-exclude .DS_Store

--- a/deepdiver/__init__.py
+++ b/deepdiver/__init__.py
@@ -8,8 +8,8 @@ Part of Jerry's G.Music Assembly ecosystem.
 """
 
 __version__ = "0.1.0"
-__author__ = "Jerry's G.Music Assembly"
-__email__ = ""
+__author__ = "gerico1007"
+__email__ = "gerico@jgwill.com"
 __description__ = "NotebookLM Podcast Automation System"
 
 # Assembly Team

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,77 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "deepdiver"
+version = "0.1.0"
+authors = [
+    {name = "gerico1007", email = "gerico@jgwill.com"}
+]
+description = "NotebookLM Podcast Automation System - Automate podcast creation from documents"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Multimedia :: Sound/Audio",
+    "Topic :: Office/Business",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+keywords = ["notebooklm", "podcast", "automation", "audio", "browser-automation", "playwright"]
+dependencies = [
+    "playwright>=1.40.0",
+    "pyyaml>=6.0",
+    "requests>=2.31.0",
+    "beautifulsoup4>=4.12.0",
+    "pyperclip>=1.8.2",
+    "click>=8.1.0",
+    "rich>=13.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.4.0",
+    "pytest-asyncio>=0.21.0",
+    "black>=23.0.0",
+    "flake8>=6.0.0",
+    "mypy>=1.5.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/Gerico1007/deepdiver"
+Repository = "https://github.com/Gerico1007/deepdiver"
+Issues = "https://github.com/Gerico1007/deepdiver/issues"
+
+[project.scripts]
+deepdiver = "deepdiver.deepdive:main"
+
+[tool.setuptools]
+packages = ["deepdiver"]
+
+[tool.setuptools.package-data]
+deepdiver = ["*.yaml", "*.yml"]
+
+[tool.black]
+line-length = 100
+target-version = ['py38', 'py39', 'py310', 'py311']
+
+[tool.mypy]
+python_version = "3.8"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = "test_*.py"
+python_functions = "test_*"
+asyncio_mode = "auto"

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ with open("README.md", "r", encoding="utf-8") as fh:
 setup(
     name="deepdiver",
     version="0.1.0",
-    author="Jerry's G.Music Assembly",
-    author_email="",
+    author="gerico1007",
+    author_email="gerico@jgwill.com",
     description="NotebookLM Podcast Automation System",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## Summary
Successfully created and published the DeepDiver package to PyPI, enabling installation via `pip install deepdiver`

## Changes Made
- Added `pyproject.toml` with modern Python packaging standards
- Added `MANIFEST.in` for package file inclusion
- Added MIT `LICENSE` file
- Updated `setup.py` with correct author metadata (gerico1007)
- Updated `__init__.py` with author information
- Configured console_scripts entry point for `deepdiver` CLI command
- Added development dependencies and optional extras
- Built and validated package distributions (wheel + tarball)
- **Successfully published to PyPI: https://pypi.org/project/deepdiver/0.1.0/**

## Installation
Users can now install DeepDiver with:
```bash
pip install deepdiver
```

## Test Plan
- [x] Built package with `python -m build`
- [x] Validated distributions with `twine check dist/*`
- [x] Published to PyPI successfully
- [x] Both wheel and source distributions uploaded

## PyPI Package
- **Package Name**: deepdiver
- **Version**: 0.1.0
- **PyPI URL**: https://pypi.org/project/deepdiver/0.1.0/
- **Author**: gerico1007 (gerico@jgwill.com)
- **License**: MIT

Resolves #7

♠️🌿🎸🧵 G.Music Assembly Mode
🧠 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>