### PR TITLE
[#21] Fix NotebookLM collaborator sharing

### DIFF
--- a/deepdiver/notebooklm_automator.py
+++ b/deepdiver/notebooklm_automator.py
@@ -1880,6 +1880,39 @@ class NotebookLMAutomator:
                 self.logger.info(f"📸 Screenshot saved to {screenshot_path}")
             return False
 
+    async def _dismiss_preexisting_dialogs(self) -> bool:
+        """Dismiss blocking NotebookLM overlays before clicking page-level controls."""
+        if not self.page:
+            return False
+
+        overlay_selectors = [
+            '.cdk-overlay-backdrop',
+            '.cdk-overlay-pane',
+            'div[role="dialog"]',
+        ]
+
+        overlay_visible = False
+        for selector in overlay_selectors:
+            try:
+                element = await self.page.query_selector(selector)
+                if element and await element.is_visible():
+                    overlay_visible = True
+                    self.logger.info(f"⚠️ Dismissing blocking overlay before share: {selector}")
+                    break
+            except:
+                continue
+
+        if not overlay_visible:
+            return False
+
+        try:
+            await self.page.keyboard.press('Escape')
+            await self.page.wait_for_timeout(500)
+            return True
+        except Exception as e:
+            self.logger.warning(f"⚠️ Failed to dismiss overlay with Escape: {e}")
+            return False
+
     async def share_notebook(self, email: str, role: str = 'editor') -> bool:
         """
         Share the current notebook with a collaborator via email.
@@ -1897,6 +1930,7 @@ class NotebookLMAutomator:
                 return False
 
             self.logger.info(f"👥 Sharing notebook with {email} as {role}...")
+            await self._dismiss_preexisting_dialogs()
 
             # Multi-selector strategy for share button
             share_button_selectors = [

--- a/deepdiver/notebooklm_automator.py
+++ b/deepdiver/notebooklm_automator.py
@@ -1953,11 +1953,20 @@ class NotebookLMAutomator:
 
             # Find email input field
             email_input_selectors = [
+                'mat-dialog-container input#mat-input-1',
+                'mat-dialog-container input[peoplekitautocomplete]',
                 'input[type="email"]',
                 'input[aria-label*="email"]',
                 'input[aria-label*="Add people"]',
+                'input[aria-label*="people and groups"]',
                 'input[placeholder*="email"]',
-                'input.share-email-input'
+                'input.share-email-input',
+                'mat-dialog-container input',
+                'div[role="dialog"] input',
+                'div[role="dialog"] [role="combobox"]',
+                'div[role="dialog"] [contenteditable="true"]',
+                'label:has-text("Add people and groups") + div input',
+                'label:has-text("Add people and groups") + div [role="combobox"]'
             ]
 
             email_input = None
@@ -1983,6 +1992,13 @@ class NotebookLMAutomator:
             await asyncio.sleep(0.5)
             await self.page.keyboard.type(email, delay=50)
             await asyncio.sleep(1)
+
+            # Google share dialogs often need Enter to convert typed text into a recipient chip.
+            try:
+                await self.page.keyboard.press('Enter')
+                await asyncio.sleep(1)
+            except:
+                pass
 
             # Select role if dropdown available
             if role != 'editor':
@@ -2022,6 +2038,7 @@ class NotebookLMAutomator:
             send_button_selectors = [
                 'button:has-text("Send")',
                 'button:has-text("Share")',
+                'button:has-text("Save")',
                 'button:has-text("Invite")',
                 'button[aria-label="Send"]',
                 'button[type="submit"]'

--- a/tests/test_share_overlays.py
+++ b/tests/test_share_overlays.py
@@ -1,0 +1,49 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+from deepdiver.notebooklm_automator import NotebookLMAutomator
+
+
+class _VisibleElement:
+    def __init__(self, visible=True):
+        self.is_visible = AsyncMock(return_value=visible)
+        self.click = AsyncMock()
+
+
+def _make_automator_with_page(query_selector_impl):
+    automator = NotebookLMAutomator()
+    page = MagicMock()
+    page.query_selector = AsyncMock(side_effect=query_selector_impl)
+    page.wait_for_timeout = AsyncMock()
+    page.keyboard = MagicMock()
+    page.keyboard.press = AsyncMock()
+    automator.page = page
+    return automator, page
+
+
+def test_dismiss_preexisting_dialog_uses_escape_when_overlay_is_visible():
+    async def query_selector(selector):
+        if selector == '.cdk-overlay-backdrop':
+            return _VisibleElement(True)
+        return None
+
+    automator, page = _make_automator_with_page(query_selector)
+
+    dismissed = asyncio.run(automator._dismiss_preexisting_dialogs())
+
+    assert dismissed is True
+    page.keyboard.press.assert_awaited_once_with('Escape')
+    page.wait_for_timeout.assert_awaited_once_with(500)
+
+
+def test_dismiss_preexisting_dialog_does_nothing_when_no_overlay_is_visible():
+    async def query_selector(_selector):
+        return None
+
+    automator, page = _make_automator_with_page(query_selector)
+
+    dismissed = asyncio.run(automator._dismiss_preexisting_dialogs())
+
+    assert dismissed is False
+    page.keyboard.press.assert_not_called()
+    page.wait_for_timeout.assert_not_called()


### PR DESCRIPTION
## Summary
- targets the current NotebookLM Material share dialog recipient input
- presses Enter to convert the email into a recipient chip
- accepts Save as a valid submit action

## Validation
- python3 -m py_compile deepdiver/notebooklm_automator.py

Fixes #21